### PR TITLE
Refactored Zone.names to cache.

### DIFF
--- a/lib/timezone/zone.rb
+++ b/lib/timezone/zone.rb
@@ -53,7 +53,7 @@ module Timezone
 
       # Instantly grab all possible time zone names.
       def names
-        @@names = Dir[File.join(ZONE_FILE_PATH, "**/**/*.json")].collect do |file|
+        @@names ||= Dir[File.join(ZONE_FILE_PATH, "**/**/*.json")].collect do |file|
           file.gsub("#{ZONE_FILE_PATH}/", '').gsub(/\.json/, '')
         end
       end


### PR DESCRIPTION
Names was not being cached. Here are the results from a quick benchmark comparison after 5000 calls to Timezone::Zone.names:

```
         user      system      total        real
  Old: 21.380000   6.490000  27.870000 ( 27.841006)
  New:  0.010000   0.000000   0.010000 (  0.010154)
```

New results are noticeably different.
