### PR TITLE
Make the URL of the timezone server configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .DS_Store
 .rvmrc
 .bundle
+.idea/*
 Gemfile.lock
 pkg/*

--- a/lib/timezone/configure.rb
+++ b/lib/timezone/configure.rb
@@ -9,6 +9,14 @@ module Timezone
   # your application for latitude and longitude based timezone searches. If you aren't going to
   # initialize timezone objects based on latitude and longitude then this configuration is not necessary.
   class Configure
+    def self.url
+      @@url ||= 'ws.geonames.org'
+    end
+
+    def self.url= url
+      @@url = url
+    end
+
     def self.username
       @@username
     end

--- a/lib/timezone/zone.rb
+++ b/lib/timezone/zone.rb
@@ -119,7 +119,7 @@ module Timezone
 
     def timezone_id lat, lon #:nodoc:
       begin
-        response = Net::HTTP.get('ws.geonames.org', "/timezoneJSON?lat=#{lat}&lng=#{lon}&username=#{Timezone::Configure.username}")
+        response = Net::HTTP.get(Timezone::Configure.url, "/timezoneJSON?lat=#{lat}&lng=#{lon}&username=#{Timezone::Configure.username}")
         JSON.parse(response)['timezoneId']
       rescue Exception => e
         raise Timezone::Error::GeoNames, e.message

--- a/test/timezone_test.rb
+++ b/test/timezone_test.rb
@@ -101,4 +101,16 @@ class TimezoneTest < Test::Unit::TestCase
     local = Time.utc(2010, 12, 24, 6, 7, 15)
     assert_equal local.to_i, timezone.time(utc).to_i
   end
+
+  def test_configure_url_default
+    assert_equal 'ws.geonames.org', Timezone::Configure.url
+  end
+
+  def test_configure_url_custom
+    Timezone::Configure.begin { |c| c.url = 'www.newtimezoneserver.com' }
+    assert_equal 'www.newtimezoneserver.com', Timezone::Configure.url
+    # clean up url after test
+    Timezone::Configure.begin { |c| c.url = nil }
+  end
+
 end


### PR DESCRIPTION
- Add @@url field to Configure class, with the default of
  ws.geonames.org
- Use Configure.url for the url of the timezone server in the
  Timezone.timezone_id method
- Add tests to verify that the url field can be modified using the
  Configure.begin method
- For RubyMine users, add .idea/\* path to .gitignore
