### PR TITLE
Fixed bug in DST start/end time parsing

### DIFF
--- a/lib/timezone/zone.rb
+++ b/lib/timezone/zone.rb
@@ -128,7 +128,7 @@ module Timezone
 
     def _parsetime time #:nodoc:
       begin
-        Time.strptime(time, "%Y-%m-%dT%H:%M:%SZ")
+        Time.strptime(time, "%Y-%m-%dT%H:%M:%S%Z")
       rescue Exception => e
         raise Timezone::Error::ParseTime, e.message
       end

--- a/test/timezone_test.rb
+++ b/test/timezone_test.rb
@@ -120,4 +120,24 @@ class TimezoneTest < Test::Unit::TestCase
     Timezone::Configure.begin { |c| c.url = nil }
   end
 
+  def test_utc_offset_without_dst
+    timezone = Timezone::Zone.new :zone => 'Europe/Helsinki'
+    # just before DST starts
+    utc = Time.utc(2012, 3, 25, 0, 59, 59)
+    assert_equal timezone.utc_offset(utc), 7200
+    # on the second DST ends
+    utc = Time.utc(2012, 10, 28, 1, 0, 0)
+    assert_equal timezone.utc_offset(utc), 7200
+  end
+
+  def test_utc_offset_with_dst
+    timezone = Timezone::Zone.new :zone => 'Europe/Helsinki'
+    # on the second DST starts
+    utc = Time.utc(2012, 3, 25, 1, 0, 0)
+    assert_equal timezone.utc_offset(utc), 10800
+    # right before DST end
+    utc = Time.utc(2012, 10, 28, 0, 59, 59)
+    assert_equal timezone.utc_offset(utc), 10800
+  end
+
 end


### PR DESCRIPTION
I fixed a bug in the format string used to parse DST start/end time from the tz rules: the offset information of the string was discarded, making the parsed time local for the machine on which the code was running, changing the time in which the DST starts/end by a few hours.

I also added two tests to make sure the DST kicks in at the right exact second.
