### PR TITLE
raises "api limit reached" if json response is status error 18, fixes issue 23

### DIFF
--- a/lib/timezone/zone.rb
+++ b/lib/timezone/zone.rb
@@ -148,7 +148,10 @@ module Timezone
       begin
         response = Net::HTTP.get(Timezone::Configure.url, "/timezoneJSON?lat=#{lat}&lng=#{lon}&username=#{Timezone::Configure.username}")
         id = JSON.parse(response)['timezoneId']
-        raise TimeZone::Error::GeoNames, "api limit reached" if id['status']['value'] == 18
+        if id['status']
+          raise TimeZone::Error::GeoNames, "api limit reached" if id['status']['value'] == 18
+        end
+        return id
       rescue Exception => e
         raise Timezone::Error::GeoNames, e.message
       end

--- a/test/mocks/api_limit_reached.txt
+++ b/test/mocks/api_limit_reached.txt
@@ -1,0 +1,1 @@
+{"status":{"message":"the daily limit of 30000 credits for XXXXX has been exceeded. Please throttle your requests or use the commercial service.","value":18}}

--- a/test/mocks/lat_lon_coords.txt
+++ b/test/mocks/lat_lon_coords.txt
@@ -1,0 +1,1 @@
+{"time":"2013-10-29 15:30","countryName":"Australia","sunset":"2013-10-30 19:42","rawOffset":9.5,"dstOffset":9.5,"countryCode":"AU","gmtOffset":10.5,"lng":138.477041423321,"sunrise":"2013-10-30 06:17","timezoneId":"Australia/Adelaide","lat":-34.92771808058}

--- a/test/timezone_test.rb
+++ b/test/timezone_test.rb
@@ -1,6 +1,7 @@
 require 'timezone'
 require 'timezone/zone'
 require 'test/unit'
+require "mocha/setup"
 require 'timecop'
 
 class TimezoneTest < Test::Unit::TestCase
@@ -138,9 +139,23 @@ class TimezoneTest < Test::Unit::TestCase
   end
 
   def test_using_lat_lon_coordinates
+    mock_path = File.expand_path(File.join(File.dirname(__FILE__), 'mocks'))
+    mock = File.open(mock_path + '/lat_lon_coords.txt').read
+    http_mock = mock('Net::HTTPResponse')
+    http_mock.stubs(:body).returns(mock)
     Timezone::Configure.begin { |c| c.username = 'timezone' }
     timezone = Timezone::Zone.new :latlon => [-34.92771808058, 138.477041423321]
     assert_equal 'Australia/Adelaide', timezone.zone
+  end
+
+  def test_api_limit_read_lat_lon_coordinates
+    mock_path = File.expand_path(File.join(File.dirname(__FILE__), 'mocks'))
+    mock = File.open(mock_path + '/api_limit_reached.txt').read
+    http_mock = mock('Net::HTTPResponse')
+    http_mock.stubs(:body).returns(mock)
+    assert_raise Timezone::Error::GeoNames do
+      Timezone::Zone.new :latlon => [-34.92771808058, 138.477041423321]
+    end
   end
 
   def test_australian_timezone_with_dst

--- a/timezone.gemspec
+++ b/timezone.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake')
   s.add_development_dependency('minitest', '~> 4.0')
   s.add_development_dependency('timecop')
+  s.add_development_dependency('mocha')
 end


### PR DESCRIPTION
This commit fixes issue 23 on returning nil instead of an error when the api limit is reached. It's pretty simple. Let me know if there's any problem.
