### PR TITLE
Added support for DateTime and Date objects.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,7 +22,7 @@ Metrics/AbcSize:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 190
+  Max: 219
 
 # Offense count: 32
 # Configuration parameters: AllowURI, URISchemes.

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,7 @@
+# Unreleased (master)
+
+* Added support for `DateTime` and `Date` objects. (panthomakos)
+
 # 0.4.3
 
 * Updated with tzdata-2015g-1. (panthomakos)

--- a/lib/timezone/zone.rb
+++ b/lib/timezone/zone.rb
@@ -55,6 +55,8 @@ module Timezone
     # offset in the timezone rules. Once the offset has been found that offset is added to the reference UTC time
     # to calculate the reference time in the timezone.
     def time(reference)
+      reference = sanitize(reference)
+
       reference.utc + utc_offset(reference)
     end
 
@@ -69,6 +71,8 @@ module Timezone
     # separate UTC times (during a fall back). All of these cases are ignored here and the best
     # (first) guess is used instead.
     def local_to_utc(time)
+      time = sanitize(time)
+
       time.utc - rule_for_local(time).rules.first[OFFSET_BIT]
     end
 
@@ -84,6 +88,8 @@ module Timezone
     # to calculate the reference time in the timezone. The offset is then
     # appended to put the time object into the proper offset.
     def time_with_offset(reference)
+      reference = sanitize(reference)
+
       utc = time(reference)
       offset = utc_offset(reference)
       Time.new(utc.year, utc.month, utc.day, utc.hour, utc.min, utc.sec, offset)
@@ -91,6 +97,8 @@ module Timezone
 
     # Whether or not the time in the timezone is in DST.
     def dst?(reference)
+      reference = sanitize(reference)
+
       rule_for_utc(reference)[DST_BIT]
     end
 
@@ -98,6 +106,8 @@ module Timezone
     #
     #   timezone.utc_offset(reference)
     def utc_offset(reference=Time.now)
+      reference = sanitize(reference)
+
       rule_for_utc(reference)[OFFSET_BIT]
     end
 
@@ -141,6 +151,10 @@ module Timezone
     end
 
     private
+
+    def sanitize(reference)
+      reference.to_time
+    end
 
     # Does the given time (in seconds) match this rule?
     #

--- a/test/timezone_test.rb
+++ b/test/timezone_test.rb
@@ -249,4 +249,44 @@ class TimezoneTest < ::Minitest::Unit::TestCase
     assert_equal 'America/Anchorage', timezone.zone
     assert_equal 'America/Anchorage', timezone.active_support_time_zone
   end
+
+  EQUIVALENCE_METHODS = [
+    :time,
+    :local_to_utc,
+    :time_with_offset,
+    :dst?,
+    :utc_offset
+  ]
+
+  def check_equivalence(zone, time, other)
+    tz = Timezone::Zone.new(:zone => zone)
+
+    EQUIVALENCE_METHODS.each do |m|
+      assert_equal(tz.public_send(m, time), tz.public_send(m, other))
+    end
+  end
+
+  def test_date_equivalence
+    time = Time.new(2011, 2, 3, 0, 0, 0)
+    date = Date.new(2011, 2, 3)
+
+    check_equivalence('America/Los_Angeles', time, date)
+
+    time = Time.new(2011, 6, 3, 0, 0, 0)
+    date = Date.new(2011, 6, 3)
+
+    check_equivalence('America/Los_Angeles', time, date)
+  end
+
+  def test_datetime_equivalence
+    time = Time.new(2011, 2, 3, 13, 5, 0)
+    datetime = DateTime.new(2011, 2, 3, 13, 5, 0)
+
+    check_equivalence('America/Los_Angeles', time, datetime)
+
+    time = Time.new(2011, 6, 3, 13, 5, 0)
+    datetime = DateTime.new(2011, 6, 3, 13, 5, 0)
+
+    check_equivalence('America/Los_Angeles', time, datetime)
+  end
 end


### PR DESCRIPTION
`ActiveSupport` adds `#utc` to `DateTime` and `Date` that allow both of
these objects to work with this gem instead of raising errors. To avoid
confusion and provide support for `DateTime` and `Date` in regular Ruby,
both of these objects can now be provided instead of a `Time` object. To
allow for forwards and backwards compatibility the object is always
converted into a time object.

Closes #36