### PR TITLE
[Fixes #39] Add test/stub lookups.

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,5 +1,7 @@
 # Unreleased (master)
 
+* Added `::Timezone::Lookup::Test`, which provides lookup stubs for testing frameworks. (panthomakos)
+
 # 0.5.0
 
 * Added support for `DateTime` and `Date` objects. (panthomakos)

--- a/README.markdown
+++ b/README.markdown
@@ -155,6 +155,19 @@ Be aware that the Google timezone API uses `https` protocol.
 
 For an example, see `Timezone::NetHTTPClient` which uses the standard `Net::HTTP` library to perform API calls.
 
+## Testing Timezone Lookups
+
+You can provide your own lookup stubs using the built in `::Timezone::Lookup::Test` class.
+
+    require 'timezone/lookup/test'
+
+    ::Timezone::Configure.begin{ |c| c.lookup = ::Timezone::Lookup::Test }
+
+    ::Timezone::Configure.lookup.stub(-10, 10, 'America/Los_Angeles')
+
+    ::Timezone::Zone.new(lat: -10, lon: 10).zone #=> 'America/Los_Angeles'
+    ::Timezone::Zone.new(lat: -11, lon: 11) #=> raises ::Timezone::Error::Test
+
 ## Build Status [![Build Status](https://secure.travis-ci.org/panthomakos/timezone.png?branch=master)](http://travis-ci.org/panthomakos/timezone)
 
 ## Code Quality [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/panthomakos/timezone)

--- a/lib/timezone/configure.rb
+++ b/lib/timezone/configure.rb
@@ -70,7 +70,13 @@ module Timezone
       use_google? && !!google_client_id
     end
 
+    def self.lookup=(lookup)
+      @lookup = lookup && lookup.new(self)
+    end
+
     def self.lookup
+      return @lookup if @lookup
+
       use_google? ? google_lookup : geonames_lookup
     end
 

--- a/lib/timezone/error.rb
+++ b/lib/timezone/error.rb
@@ -13,6 +13,7 @@ module Timezone
     class GeoNames < Base; end
     class Google < Base; end
     class ParseTime < Base; end
+    class Test < Base ; end
     class InvalidConfig < Base ; end
   end
 end

--- a/lib/timezone/lookup/test.rb
+++ b/lib/timezone/lookup/test.rb
@@ -1,0 +1,29 @@
+require 'timezone/lookup/basic'
+require 'timezone/error'
+
+module Timezone
+  module Lookup
+    class Test < ::Timezone::Lookup::Basic
+      def initialize(config)
+        @stubs = {}
+        # Regular config w/ protocol and URL checks does not apply for stubs.
+      end
+
+      def stub(lat, lng, timezone)
+        @stubs[key(lat, lng)] = timezone
+      end
+
+      def lookup(lat, lng)
+        @stubs.fetch(key(lat, lng)) do
+          raise ::Timezone::Error::Test, 'missing stub'
+        end
+      end
+
+      private
+
+      def key(lat, lng)
+        "#{lat},#{lng}"
+      end
+    end
+  end
+end

--- a/test/test_lookup_test.rb
+++ b/test/test_lookup_test.rb
@@ -1,0 +1,39 @@
+require 'timezone/configure'
+require 'timezone/lookup/test'
+require 'timezone/zone'
+require 'minitest/autorun'
+
+class TestLookupTest < ::Minitest::Unit::TestCase
+  def setup
+    Timezone::Configure.begin do |c|
+      c.lookup = ::Timezone::Lookup::Test
+    end
+  end
+
+  def test_simple_stub
+    ::Timezone::Configure.lookup.stub(-10, 10, 'America/Los_Angeles')
+
+    assert_equal(
+      'America/Los_Angeles',
+      ::Timezone::Zone.new(lat: -10, lon: 10).zone)
+  end
+
+  def test_missing_stub
+    assert_raises(::Timezone::Error::Test) do
+      ::Timezone::Zone.new(lat: 100, lon: 100)
+    end
+  end
+
+  def test_clear_lookup
+    ::Timezone::Configure.begin do |c|
+      c.username = 'foo'
+      c.lookup = nil
+    end
+
+    assert ::Timezone::Lookup::Geonames, ::Timezone::Configure.lookup.class
+  end
+
+  def teardown
+    Timezone::Configure.begin{ |c| c.lookup = nil }
+  end
+end


### PR DESCRIPTION
* Added `::Timezone::Lookup::Test`. It can be used to configure
  stubbed timezone lookups.
* Added README instructions for stubbing timezone lookups.