### PR TITLE
Fixed lambda syntax for Ruby 1.9.3

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,6 +1,7 @@
 # master (unreleased)
 
 * Updated with `tzdata-2016c-1`. (panthomakos)
+* [#51](https://github.com/panthomakos/timezone/issues/51) Fixed syntax for Ruby 1.9.3. (panthomakos)
 
 # 0.99.1
 

--- a/lib/timezone/deprecate.rb
+++ b/lib/timezone/deprecate.rb
@@ -20,7 +20,7 @@ module Timezone
 
       # @!visibility private
       def callback
-        @callback || -> (_, _, message) { warn(message) }
+        @callback || ->(_, _, message) { warn(message) }
       end
 
       # @!visibility private


### PR DESCRIPTION
Ruby 1.9.3 does not support `->` syntax with a space after the greater
than sign. Even though Ruby 1.9.3 is not supported, this is a reasonable
change to make.

Fixes #51