### PR TITLE
Add Geonames radius option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -87,6 +87,10 @@ For more information on the `::Timezone::Zone` object, see the [RubyDocs](http:/
 
         Timezone::Lookup.config(:geonames) do |c|
           c.username = 'your_geonames_username_goes_here'
+
+          # Optional - sets a radius in km to find the timezone
+          #            for the closest point of land in the circle
+          c.radius = 10
         end
 
 ### Lookup Configuration with Google

--- a/lib/timezone/configure.rb
+++ b/lib/timezone/configure.rb
@@ -110,6 +110,8 @@ module Timezone
       def http_client; @config.http_client; end
 
       def request_handler; nil; end
+
+      def radius; @config.radius; end
     end
 
     private_constant :GeonamesConfigMapper
@@ -209,6 +211,18 @@ module Timezone
     #   of the `timezone gem. Use `Timezone::Lookup instead.
     def self.username=(username)
       @@username = username
+    end
+
+    # @deprecated `Timezone::Configure` will be removed in the release
+    #   of the `timezone gem. Use `Timezone::Lookup instead.
+    def self.radius
+      @@radius ||= 0
+    end
+
+    # @deprecated `Timezone::Configure` will be removed in the release
+    #   of the `timezone gem. Use `Timezone::Lookup instead.
+    def self.radius=(radius)
+      @@radius = radius
     end
 
     # @deprecated `Timezone::Configure` will be removed in the release

--- a/lib/timezone/lookup/geonames.rb
+++ b/lib/timezone/lookup/geonames.rb
@@ -14,7 +14,7 @@ module Timezone
 
         config.protocol ||= 'http'.freeze
         config.url ||= 'api.geonames.org'.freeze
-
+        config.radius ||= 0
         super
       end
 
@@ -40,6 +40,7 @@ module Timezone
         query = URI.encode_www_form(
           'lat' => lat,
           'lng' => long,
+          'radius' => config.radius,
           'username' => config.username)
         "/timezoneJSON?#{query}"
       end


### PR DESCRIPTION
Geonames has an option to use a radius (eg: in case your lat/long is over water or has no value) where it will find the closest point with a timezone inside that circle and return it.

It's used as a config option and documented in the README.
