### PR TITLE
Adding support for a default stub

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -7,6 +7,7 @@
 * Remove deprecated code. (panthomakos)
 * Updated with `tzdata-2016d-1`. (panthomakos)
 * Improve Geonames exception messaging. (panthomakos)
+* Allowing a default stub (garyharan)
 
 # 0.99.2
 

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,13 +1,13 @@
 # master (unreleased)
 
 * Changed binary search method of zone for mathn compatibility. (cbillen)
+* Allowing a default stub (garyharan)
 
 # 1.0.0
 
 * Remove deprecated code. (panthomakos)
 * Updated with `tzdata-2016d-1`. (panthomakos)
 * Improve Geonames exception messaging. (panthomakos)
-* Allowing a default stub (garyharan)
 
 # 0.99.2
 

--- a/lib/timezone/lookup/test.rb
+++ b/lib/timezone/lookup/test.rb
@@ -7,15 +7,20 @@ module Timezone
     class Test < ::Timezone::Lookup::Basic
       def initialize(_config)
         @stubs = {}
+        @default_stub = nil
       end
 
       def stub(lat, long, timezone)
         @stubs[key(lat, long)] = timezone
       end
 
+      def default_stub(timezone)
+        @default_stub = timezone
+      end
+
       def lookup(lat, long)
         @stubs.fetch(key(lat, long)) do
-          raise ::Timezone::Error::Test, 'missing stub'
+          @default_stub || raise(::Timezone::Error::Test, 'missing stub')
         end
       end
 

--- a/lib/timezone/lookup/test.rb
+++ b/lib/timezone/lookup/test.rb
@@ -14,7 +14,7 @@ module Timezone
         @stubs[key(lat, long)] = timezone
       end
 
-      def default_stub(timezone)
+      def default(timezone)
         @default_stub = timezone
       end
 

--- a/test/timezone/lookup/test_test.rb
+++ b/test/timezone/lookup/test_test.rb
@@ -21,4 +21,11 @@ class TestTest < ::Minitest::Test
       lookup.lookup(100, 100)
     end
   end
+
+  def test_default_stub
+    mine = lookup
+    mine.default_stub('America/Toronto')
+
+    assert_equal 'America/Toronto', mine.lookup(-12, 12)
+  end
 end

--- a/test/timezone/lookup/test_test.rb
+++ b/test/timezone/lookup/test_test.rb
@@ -24,7 +24,7 @@ class TestTest < ::Minitest::Test
 
   def test_default_stub
     mine = lookup
-    mine.default_stub('America/Toronto')
+    mine.default('America/Toronto')
 
     assert_equal 'America/Toronto', mine.lookup(-12, 12)
   end


### PR DESCRIPTION
This comes in really handy when using a test runner that generates various
addresses on the fly.  If you have thousand of addresses to timezone
it's more effective to use a default for this very common scenario.

I'd be glad to make any changes if this PR requires any more work to be accepted.

Cheers!