### PR TITLE
Make timezone compatible with gem requiring mathn (e.g.ruby-units)

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,5 +1,7 @@
 # master (unreleased)
 
+* Changed binary search method of zone for mathn compatibility
+
 # 1.0.0
 
 * Remove deprecated code. (panthomakos)

--- a/lib/timezone/zone.rb
+++ b/lib/timezone/zone.rb
@@ -236,7 +236,7 @@ module Timezone
 
       return from if from == to
 
-      mid = ((from + to) / 2).to_i
+      mid = (from + to).div(2)
 
       if yield(time, private_rules[mid])
         return mid if mid == 0

--- a/lib/timezone/zone.rb
+++ b/lib/timezone/zone.rb
@@ -236,7 +236,7 @@ module Timezone
 
       return from if from == to
 
-      mid = (from + to) / 2
+      mid = ((from + to) / 2).to_i
 
       if yield(time, private_rules[mid])
         return mid if mid == 0

--- a/test/timezone/test_mathn_compatibility.rb
+++ b/test/timezone/test_mathn_compatibility.rb
@@ -1,0 +1,11 @@
+require 'timezone'
+require 'minitest/autorun'
+require 'mathn'
+
+class TestTimezone < ::Minitest::Test
+  parallelize_me!
+
+  def test_lookup_mathn_compatibility
+    Timezone['America/Regina'].utc_offset
+  end
+end


### PR DESCRIPTION
When used inside a project requiring mathn, such as ruby-units, the binary search method will fail on certain timezone with a stack too deep 

this is due to the fact that mathn will override divisions and not return an integer when two integers are divided.  this simple fix cast the mid value to integer in those case.

To reproduce the problem in an unpatched version:

rb(main):001:0> require 'timezone'
=> true
irb(main):002:0> tz = Timezone['America/Regina'];tz.utc_offset
=> -21600
irb(main):003:0> require 'mathn'
=> true
irb(main):004:0> tz = Timezone['America/Regina'];tz.utc_offset
SystemStackError: stack level too deep
