### PR TITLE
Added lookup_with_etc method

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,5 +1,6 @@
 # master (unreleased)
 
+* Added support for lookups of `Etc` areas with Geonames (tgrave)
 * Changed binary search method of zone for mathn compatibility. (cbillen)
 * Allowed a default test stub. (garyharan)
 * Updated with `tzdata-2016e-1`. (panthomakos)

--- a/README.markdown
+++ b/README.markdown
@@ -103,6 +103,30 @@ After configuring the API of your choice, pass the lookup coordinates to `Timezo
     timezone.utc_to_local(Time.now)
     => 2011-02-12 12:02:13 UTC
 
+### Latitude - Longitude Lookups for [Etcetera](https://www.ietf.org/timezones/data/etcetera) areas
+
+By default both Geonames and Google do not provide results for lookups outside of continents and country borders. For example, if you try coordinates `[0, 0]` (somewhere in the Atlantic Ocean), you will get an exception.
+
+But there is a way to get lookups for the whole Earth surface working (with Geonames only). Just add the `offset_etc_areas` option to the lookup configuration:
+
+        Timezone::Lookup.config(:geonames) do |c|
+          c.username = 'your_geonames_username_goes_here'
+          c.offset_etc_zones = true
+        end
+
+Then try to lookup coordinates in Etc area:
+
+    timezone = Timezone.lookup(89, 40)
+    => #<Timezone::Zone name: "Etc/GMT-3">
+
+    timezone.name
+    => "Etc/GMT-3"
+
+    timezone.utc_offset
+    => 10800
+
+NOTE: `Etc/GMT` zones have POSIX-style signs in their names, with positive signs west of Greenwich. For example, "Etc/GMT-3" zone has a negative sign, but a positive UTC offset (10800 seconds or +3 hours) and its time is ahead of UTC (east of Greenwich) by 3 hours.
+
 ## Error States and Nil Objects
 
 All exceptions raised by the `timezone` gem are subclasses of `::Timezone::Error::Base`. `timezone` also provides a default `nil` timezone object that behaves like a `Timezone::Zone` except that it is invalid.

--- a/lib/timezone/lookup/geonames.rb
+++ b/lib/timezone/lookup/geonames.rb
@@ -25,7 +25,8 @@ module Timezone
 
         data = JSON.parse(response.body)
 
-        return data['timezoneId'] if data['timezoneId']
+        timezone_id = get_timezone_id(data)
+        return timezone_id if timezone_id
 
         return unless data['status']
 
@@ -35,6 +36,16 @@ module Timezone
       end
 
       private
+
+      def get_timezone_id(data)
+        return data['timezoneId'] if data['timezoneId']
+
+        if config.offset_etc_zones && data['gmtOffset']
+          return unless data['gmtOffset'].is_a? Numeric
+          return 'Etc/UTC' if data['gmtOffset'] == 0
+          "Etc/GMT#{format('%+d', -data['gmtOffset'])}"
+        end
+      end
 
       def url(lat, long)
         query = URI.encode_www_form(

--- a/test/mocks/lat_lon_coords_arctic.txt
+++ b/test/mocks/lat_lon_coords_arctic.txt
@@ -1,0 +1,1 @@
+{"rawOffset":3,"dstOffset":0,"gmtOffset":3,"lng":40,"lat":89}

--- a/test/mocks/lat_lon_coords_atlantic.txt
+++ b/test/mocks/lat_lon_coords_atlantic.txt
@@ -1,0 +1,1 @@
+{"rawOffset":0,"dstOffset":0,"gmtOffset":0,"lng":0,"lat":0}

--- a/test/mocks/lat_lon_coords_norfolk.txt
+++ b/test/mocks/lat_lon_coords_norfolk.txt
@@ -1,0 +1,1 @@
+{"rawOffset":11.5,"dstOffset":0,"gmtOffset":11.5,"lng":167,"lat":-29}

--- a/test/mocks/lat_lon_coords_wrong_offset.txt
+++ b/test/mocks/lat_lon_coords_wrong_offset.txt
@@ -1,0 +1,1 @@
+{"rawOffset":11.5,"dstOffset":0,"gmtOffset":"n/a","lng":167,"lat":-29}


### PR DESCRIPTION
Added lookup_with_etc method to get timezones for the whole Earth surface (including oceans and other "Etcetera" areas). Geonames only (since Google API returns ZERO_RESULTS for Etc areas).