### PR TITLE
Added Timezone::Zone#abbr Method

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,5 +1,7 @@
 # master (unreleased)
 
+* Added `::Timezone::Zone#abbr` method. (panthomakos)
+
 # 1.1.1
 
 * Updated with `tzdata-2016f-1`. (panthomakos)

--- a/README.markdown
+++ b/README.markdown
@@ -38,6 +38,9 @@ Simple querying of time, in any timezone, is accomplished by first retrieving a 
     timezone.time_with_offset(Time.utc(2010, 1, 1, 0, 0, 0))
     => 2009-12-31 16:00:00 -0800
 
+    timezone.abbr(Time.new(2016, 9, 4, 1, 0, 0))
+    => "PDT"
+
 NOTE: time is always returned in the UTC timezone when using the `utc_to_local` function, but it accurately reflects the actual time in the specified timezone. The reason for this is that this function also takes into account daylight savings time and historical changes in timezone, which can alter the offset. If you want a time with the appropriate offset at the given time, then use the `time_with_offset` function as shown above.
 
 You can use the timezone object to convert local times into the best UTC

--- a/lib/timezone/zone.rb
+++ b/lib/timezone/zone.rb
@@ -123,6 +123,16 @@ module Timezone
       Time.new(utc.year, utc.month, utc.day, utc.hour, utc.min, utc.sec, offset)
     end
 
+    # The timezone abbreviation, at the given time.
+    #
+    # @param time [#to_time] the source time
+    # @return [String] the timezone abbreviation, at the given time
+    def abbr(time)
+      time = sanitize(time)
+
+      rule_for_utc(time)[NAME_BIT]
+    end
+
     # If, at the given time, the timezone was observing Daylight Savings.
     #
     # @param time [#to_time] the source time

--- a/test/timezone/test_zone.rb
+++ b/test/timezone/test_zone.rb
@@ -30,6 +30,11 @@ class TestZone < ::Minitest::Test
     assert_equal 'Europe/Paris', paris.name
   end
 
+  def test_abbr
+    assert_equal 'PDT', la.abbr(Time.new(2011, 6, 05))
+    assert_equal 'PST', la.abbr(Time.new(2011, 11, 20))
+  end
+
   def test_valid?
     assert la.valid?
     assert paris.valid?


### PR DESCRIPTION
Given a source time, return the timezone abbreviation. For example, the
`America/Los_Angeles` timezone is `PST` or `PDT`.

Closes #64