### PR TITLE
[Fix #71] Make lookups thread-safe

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,5 +1,7 @@
 # master (unreleased)
 
+* Fix [#71](https://github.com/panthomakos/timezone/issues/71): make lookups thread-safe. (panthomakos)
+
 # 1.2.4
 
 * Updated with `tzdata-2016j-1`. (panthomakos)

--- a/lib/timezone/lookup/basic.rb
+++ b/lib/timezone/lookup/basic.rb
@@ -18,6 +18,8 @@ module Timezone
           raise(::Timezone::Error::InvalidConfig, 'missing url')
         end
 
+        config.uri ||= URI.parse("#{config.protocol}://#{config.url}")
+
         @config = config
       end
 
@@ -25,7 +27,7 @@ module Timezone
       #
       # @return [#get] an instance of a request handler
       def client
-        @client ||= config.request_handler.new(config)
+        config.request_handler.new(config)
       end
 
       # Returns a timezone name for a given lat, long pair.

--- a/lib/timezone/net_http_client.rb
+++ b/lib/timezone/net_http_client.rb
@@ -16,8 +16,7 @@ module Timezone
   #
   class NetHTTPClient
     def initialize(config)
-      uri = URI.parse("#{config.protocol}://#{config.url}")
-      @http = Net::HTTP.new(uri.host, uri.port)
+      @http = Net::HTTP.new(config.uri.host, config.uri.port)
       @http.open_timeout = config.open_timeout || 5
       @http.read_timeout = config.read_timeout || 5
       @http.use_ssl = (config.protocol == 'https'.freeze)

--- a/test/http_test_client.rb
+++ b/test/http_test_client.rb
@@ -12,3 +12,13 @@ class HTTPTestClient
     HTTPTestClient::Response.new(body)
   end
 end
+
+class HTTPTestClientFactory
+  def initialize(body)
+    @body = body
+  end
+
+  def new(config)
+    HTTPTestClient.new(config).tap { |c| c.body = @body }
+  end
+end

--- a/test/threadsafe_lookup.rb
+++ b/test/threadsafe_lookup.rb
@@ -1,0 +1,17 @@
+require 'timezone'
+
+# Simple script to validate that lookups are threadsafe.
+#
+# Usage: bundle exec ruby -Ilib test/threadsafe_lookup.rb USERNAME
+
+raise 'You must specify a geonames username' unless ARGV.first
+
+Timezone::Lookup.config(:geonames) do |c|
+  c.username = ARGV.first
+end
+
+threads = Array.new(5).map do
+  Thread.new { p Timezone.lookup(33.7489954, -84.3879824).name }
+end
+
+threads.map(&:join)

--- a/test/timezone/lookup/test_basic.rb
+++ b/test/timezone/lookup/test_basic.rb
@@ -1,11 +1,12 @@
 require 'timezone/lookup/basic'
 require 'minitest/autorun'
+require 'ostruct'
 
 class BasicLookupTest < ::Minitest::Test
   parallelize_me!
 
   def config
-    @config ||= Struct.new(:protocol, :url).new('http', 'example.com')
+    @config ||= OpenStruct.new(protocol: 'http', url: 'example.com')
   end
 
   def lookup


### PR DESCRIPTION
`Net::HTTP`, in Ruby's standard library, is not threadsafe. The issue is
easy to sidestep by creating a new `Net::HTTP` object for every lookup.
The overhead of creating a new object compared to the network lookup
call is trivial.