### PR TITLE
Support fractional seconds

### DIFF
--- a/lib/timezone/zone.rb
+++ b/lib/timezone/zone.rb
@@ -120,7 +120,16 @@ module Timezone
 
       utc = utc_to_local(time)
       offset = utc_offset(time)
-      Time.new(utc.year, utc.month, utc.day, utc.hour, utc.min, utc.sec, offset)
+
+      Time.new(
+        utc.year,
+        utc.month,
+        utc.day,
+        utc.hour,
+        utc.min,
+        utc.sec + utc.subsec,
+        offset
+      )
     end
 
     # The timezone abbreviation, at the given time.

--- a/test/timezone/test_zone.rb
+++ b/test/timezone/test_zone.rb
@@ -165,6 +165,16 @@ class TestZone < ::Minitest::Test
     )
   end
 
+  def test_time_with_offset_and_fractional_seconds
+    utc = Time.utc(2011, 1, 4, 3, 51, 29.123)
+    time_with_offset = zone('Asia/Kathmandu').time_with_offset(utc)
+    assert_equal 123_000, time_with_offset.usec
+
+    utc = Time.utc(2011, 1, 4, 3, 51, 29, 123_456)
+    time_with_offset = zone('Asia/Kathmandu').time_with_offset(utc)
+    assert_equal 123_456, time_with_offset.usec
+  end
+
   def test_australian_timezone_with_dst
     utc = Time.utc(2010, 12, 23, 19, 37, 15)
     local = Time.utc(2010, 12, 24, 6, 7, 15)


### PR DESCRIPTION
A `Time` instance can be instantiated with the seconds as a fraction:

```ruby
time = Time.new(2017, 8, 7, 11, 29, 16.123)
time.sec # => 16
time.usec # => 123000
```

However, when using `Timezone`, the conversion to a time with offset loses the fractional seconds:

```ruby
time_with_offset = Timezone['America/Chicago'].time_with_offset(time)
time_with_offset.sec # => 16
time_with_offset.usec # => 0
```

This happens because we construct a new `Time` object by calling `sec` on a time object - which [will only return whole seconds](https://ruby-doc.org/core-2.4.1/Time.html#method-i-sec).

This PR accounts for fractional seconds, so that the microseconds on the time with offset match the original time:

```ruby
time_with_offset = Timezone['America/Chicago'].time_with_offset(time)
time_with_offset.sec # => 16
time_with_offset.usec # => 123000
```