### PR TITLE
Support for Ruby 2.0 and 2.1 has ended.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ branches:
 script:
   - bundle exec rake
 rvm:
-  - 2.0.0-p648
-  - 2.1.9
-  - 2.2.5
-  - 2.3.1
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/
https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/

Switch to pre-compiled patch-versions of Ruby.