### PR TITLE
Update RuboCop to v0.51

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.0
+  TargetRubyVersion: 2.2
 
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
@@ -54,6 +54,13 @@ Performance/RedundantBlockCall:
   Enabled: true
 
 
+Naming/MethodName:
+  Enabled: true
+
+Naming/BinaryOperatorParameterName:
+  Enabled: true
+
+
 Style/ClassVars:
   Enabled: true
 
@@ -72,14 +79,8 @@ Style/GuardClause:
 Style/HashSyntax:
   Enabled: true
 
-Style/MethodName:
-  Enabled: true
-
 Style/NumericLiterals:
   MinDigits: 5
-
-Style/OpMethod:
-  Enabled: true
 
 Style/PreferredHashMethods:
   Enabled: true
@@ -104,3 +105,6 @@ Style/TrivialAccessors:
 
 Style/UnneededPercentQ:
   Enabled: true
+
+Style/DateTime:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ branches:
 script:
   - bundle exec rake
 rvm:
-  - 2.0.0-p648
   - 2.1.9
   - 2.2.5
   - 2.3.1

--- a/lib/timezone/lookup.rb
+++ b/lib/timezone/lookup.rb
@@ -34,39 +34,39 @@ module Timezone
         yield(options.config) if block_given?
         @lookup = options.make_lookup
       end
+    end
 
-      # Responsible for collecting options in the DSL and creating
-      # lookup objects using those options.
-      class OptionSetter
-        LOOKUPS = {
-          geonames: ::Timezone::Lookup::Geonames,
-          google: ::Timezone::Lookup::Google,
-          test: ::Timezone::Lookup::Test
-        }.freeze
+    # Responsible for collecting options in the DSL and creating
+    # lookup objects using those options.
+    class OptionSetter
+      LOOKUPS = {
+        geonames: ::Timezone::Lookup::Geonames,
+        google: ::Timezone::Lookup::Google,
+        test: ::Timezone::Lookup::Test
+      }.freeze
 
-        INVALID_LOOKUP = 'Invalid lookup specified'.freeze
+      INVALID_LOOKUP = 'Invalid lookup specified'.freeze
 
-        attr_reader :config
+      attr_reader :config
 
-        def initialize(lookup)
-          if lookup.is_a?(Symbol)
-            lookup = LOOKUPS.fetch(lookup) do
-              raise ::Timezone::Error::InvalidConfig, INVALID_LOOKUP
-            end
+      def initialize(lookup)
+        if lookup.is_a?(Symbol)
+          lookup = LOOKUPS.fetch(lookup) do
+            raise ::Timezone::Error::InvalidConfig, INVALID_LOOKUP
           end
-
-          @lookup = lookup
-
-          @config = OpenStruct.new
         end
 
-        def make_lookup
-          config.request_handler ||= ::Timezone::NetHTTPClient
-          @lookup.new(config)
-        end
+        @lookup = lookup
+
+        @config = OpenStruct.new
       end
 
-      private_constant :OptionSetter
+      def make_lookup
+        config.request_handler ||= ::Timezone::NetHTTPClient
+        @lookup.new(config)
+      end
     end
+
+    private_constant :OptionSetter
   end
 end

--- a/lib/timezone/lookup/geonames.rb
+++ b/lib/timezone/lookup/geonames.rb
@@ -41,7 +41,7 @@ module Timezone
         return if NO_TIMEZONE_INFORMATION == data['status']['value']
 
         raise(Timezone::Error::GeoNames, data['status']['message'])
-      rescue => e
+      rescue StandardError => e
         raise(Timezone::Error::GeoNames, e.message)
       end
 

--- a/lib/timezone/lookup/google.rb
+++ b/lib/timezone/lookup/google.rb
@@ -44,7 +44,7 @@ module Timezone
         end
 
         data['timeZoneId']
-      rescue => e
+      rescue StandardError => e
         raise(Timezone::Error::Google, e.message)
       end
 

--- a/timezone.gemspec
+++ b/timezone.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ['--charset=UTF-8']
   s.require_paths    = ['lib']
 
-  s.add_development_dependency('rake')
   s.add_development_dependency('minitest', '~> 5.8')
-  s.add_development_dependency('rubocop', '= 0.49.1')
+  s.add_development_dependency('rake')
+  s.add_development_dependency('rubocop', '= 0.51')
   s.add_development_dependency('timecop', '~> 0.8')
 end


### PR DESCRIPTION
Take out `Timezone::Lookup::OptionSetter` from `class << self` due to false-positive RuboCop warning.

More info [here](https://github.com/bbatsov/rubocop/issues/5022).