### PR TITLE
Add `timestamp` parameter for Google

### DIFF
--- a/lib/timezone/lookup/google.rb
+++ b/lib/timezone/lookup/google.rb
@@ -27,8 +27,8 @@ module Timezone
         super
       end
 
-      def lookup(lat, long)
-        response = client.get(url(lat, long))
+      def lookup(lat, long, timestamp: Time.now.to_i)
+        response = client.get(url(lat, long, timestamp: timestamp))
 
         if response.code == '403'
           raise(Timezone::Error::Google, '403 Forbidden')
@@ -69,10 +69,10 @@ module Timezone
         end
       end
 
-      def url(lat, long)
+      def url(lat, long, timestamp:)
         query = URI.encode_www_form(
           'location' => "#{lat},#{long}",
-          'timestamp' => Time.now.to_i
+          'timestamp' => timestamp
         )
 
         authorize("/maps/api/timezone/json?#{query}")

--- a/test/mocks/google_lat_lon_coords_and_timestamp.txt
+++ b/test/mocks/google_lat_lon_coords_and_timestamp.txt
@@ -1,0 +1,7 @@
+{
+   "dstOffset": 0,
+   "rawOffset": 10800,
+   "status": "OK",
+   "timeZoneId": "Africa/Khartoum",
+   "timeZoneName": "East Africa Time"
+}

--- a/test/timezone/lookup/test_google.rb
+++ b/test/timezone/lookup/test_google.rb
@@ -38,6 +38,17 @@ class TestGoogle < ::Minitest::Test
     assert_equal 'Australia/Adelaide', mine.lookup(*coordinates)
   end
 
+  def test_google_using_lat_long_coordinates_and_timestamp
+    mine = lookup(
+      File.open(mock_path + '/google_lat_lon_coords_and_timestamp.txt').read
+    )
+
+    assert_equal(
+      'Africa/Khartoum',
+      mine.lookup(*coordinates, timestamp: Time.new(2016, 3, 15, 0, 0, 0).to_i)
+    )
+  end
+
   def test_google_request_denied_read_lat_long_coordinates
     mine = lookup(nil)
 


### PR DESCRIPTION
It's helpful for timezones changes.

Example:

https://maps.googleapis.com/maps/api/timezone/json?location=17.997452,29.609762&timestamp=1458000000

https://maps.googleapis.com/maps/api/timezone/json?location=17.997452,29.609762&timestamp=1510228370