### PR TITLE
Remove warnings on `gem build`

### DIFF
--- a/timezone.gemspec
+++ b/timezone.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.require_paths    = ['lib']
 
   s.add_development_dependency('minitest', '~> 5.8')
-  s.add_development_dependency('rake')
+  s.add_development_dependency('rake', '~> 12')
   s.add_development_dependency('rubocop', '= 0.51')
   s.add_development_dependency('timecop', '~> 0.8')
 end


### PR DESCRIPTION
Specify `rake` version