### PR TITLE
Errors on frozen time

### DIFF
--- a/lib/timezone/zone.rb
+++ b/lib/timezone/zone.rb
@@ -61,7 +61,7 @@ module Timezone
     def utc_to_local(time)
       time = sanitize(time)
 
-      time.utc + utc_offset(time)
+      (time + utc_offset(time)).utc
     end
 
     alias time utc_to_local
@@ -109,7 +109,7 @@ module Timezone
     def local_to_utc(time)
       time = sanitize(time)
 
-      time.utc - rule_for_local(time).rules.first[OFFSET_BIT]
+      (time - rule_for_local(time).rules.first[OFFSET_BIT]).utc
     end
 
     # Converts the given time to the local timezone and includes the UTC
@@ -199,7 +199,6 @@ module Timezone
     private_constant :RuleSet
 
     def rule_for_local(local)
-      local = local.utc if local.respond_to?(:utc)
       local = local.to_i
 
       # For each rule, convert the local time into the UTC equivalent for
@@ -245,7 +244,6 @@ module Timezone
     end
 
     def rule_for_utc(time)
-      time = time.utc if time.respond_to?(:utc)
       time = time.to_i
 
       private_rules[binary_search(time) { |t, r| match?(t, r) }]

--- a/test/timezone/test_zone.rb
+++ b/test/timezone/test_zone.rb
@@ -12,11 +12,11 @@ class TestZone < ::Minitest::Test
   end
 
   def utc_offset(name, year, month, day)
-    zone(name).utc_offset(Time.new(year, month, day))
+    zone(name).utc_offset(Time.new(year, month, day).freeze)
   end
 
   def dst?(name, year, month, day)
-    zone(name).dst?(Time.new(year, month, day))
+    zone(name).dst?(Time.new(year, month, day).freeze)
   end
 
   def la
@@ -33,8 +33,8 @@ class TestZone < ::Minitest::Test
   end
 
   def test_abbr
-    assert_equal 'PDT', la.abbr(Time.new(2011, 6, 5))
-    assert_equal 'PST', la.abbr(Time.new(2011, 11, 20))
+    assert_equal 'PDT', la.abbr(Time.new(2011, 6, 5).freeze)
+    assert_equal 'PST', la.abbr(Time.new(2011, 11, 20).freeze)
   end
 
   def test_valid?
@@ -94,7 +94,8 @@ class TestZone < ::Minitest::Test
   end
 
   def test_gmt_timezone
-    assert_equal Time.now.utc.to_i, zone('GMT').utc_to_local(Time.now).to_i
+    t = Time.now.freeze
+    assert_equal t.dup.utc.to_i, zone('GMT').utc_to_local(t).to_i
   end
 
   def test_historical_time
@@ -187,23 +188,23 @@ class TestZone < ::Minitest::Test
     timezone = zone('America/Los_Angeles')
 
     # Time maps to two rules - we pick the first
-    local = Time.utc(2015, 11, 1, 1, 50, 0)
-    utc = Time.utc(2015, 11, 1, 8, 50, 0)
+    local = Time.utc(2015, 11, 1, 1, 50, 0).freeze
+    utc = Time.utc(2015, 11, 1, 8, 50, 0).freeze
     assert_equal(utc.to_s, timezone.local_to_utc(local).to_s)
 
     # Time is above the maximum - we pick the last rule
-    local = Time.utc(3000, 1, 1, 0, 0, 0)
-    utc = Time.utc(3000, 1, 1, 8, 0, 0)
+    local = Time.utc(3000, 1, 1, 0, 0, 0).freeze
+    utc = Time.utc(3000, 1, 1, 8, 0, 0).freeze
     assert_equal(utc.to_s, timezone.local_to_utc(local).to_s)
 
     # Time maps to a single rule - we pick that rule
-    local = Time.utc(2015, 11, 1, 0, 1, 0)
-    utc = Time.utc(2015, 11, 1, 7, 1, 0)
+    local = Time.utc(2015, 11, 1, 0, 1, 0).freeze
+    utc = Time.utc(2015, 11, 1, 7, 1, 0).freeze
     assert_equal(utc.to_s, timezone.local_to_utc(local).to_s)
 
     # Time is missing - we pick the first closest rule
-    local = Time.utc(2015, 3, 8, 2, 50, 0)
-    utc = Time.utc(2015, 3, 8, 9, 50, 0)
+    local = Time.utc(2015, 3, 8, 2, 50, 0).freeze
+    utc = Time.utc(2015, 3, 8, 9, 50, 0).freeze
     assert_equal(utc.to_s, timezone.local_to_utc(local).to_s)
   end
 


### PR DESCRIPTION
As `Time#to_i` method always returns the epoch time, even if the receiver is in the local timezone, calling `Time#utc` method before it has no effect at all.
Instead, it causes a `TypeError` exception when the receiver is frozen since ruby2.4 or later, because `Time#to_time` returns the receiver itself now.
