### PR TITLE
Remove Cached Rules from Marshal Dump

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,5 +1,7 @@
 # master (unreleased)
 
+* Remove `@rules` from `Zone`'s `Marshall::dump`. (panthomakos)
+
 # 1.3.4
 
 * Updated with `tzdata-2019a-1`. (panthomakos)

--- a/lib/timezone/loader.rb
+++ b/lib/timezone/loader.rb
@@ -8,12 +8,15 @@ module Timezone # rubocop:disable Style/Documentation
     ZONE_FILE_PATH = File.expand_path(File.dirname(__FILE__) + '/../../data')
     SOURCE_BIT = 0
 
+    @rules = {} # cache of loaded rules
+
     class << self
       def load(name)
-        raise ::Timezone::Error::InvalidZone unless valid?(name)
+        @rules.fetch(name) do
+          raise ::Timezone::Error::InvalidZone unless valid?(name)
 
-        @rules ||= {}
-        @rules[name] ||= parse_zone_data(get_zone_data(name))
+          @rules[name] = parse_zone_data(get_zone_data(name))
+        end
       end
 
       def names


### PR DESCRIPTION
Whenever a calculation on `Zone` requires access to timezone rules, it
fetches them from `Loader::load` and caches them in `@rules` using the
`private_rules` method. Unfortunately, this cached data is retained
in the `Marshal::dump` output for a `Zone` even though it is entirely
unnecessary. To avoid any backwards incompatibility, while still
removing the cached `@rules` from the dump, always lookup the rule name
from the `Loader`. In order to retain performance I have also done a
little re-working of the `Loader::load` method so that it only does a
single `Hash` lookup after the initial cache population.

Fixes #97