### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/timezone.gemspec
+++ b/timezone.gemspec
@@ -16,8 +16,6 @@ Gem::Specification.new do |s|
   s.description = 'Accurate current and historical timezones for Ruby with ' \
     'support for Geonames and Google latitude - longitude lookups.'
 
-  s.rubyforge_project = 'timezone'
-
   s.files       = `git ls-files`.split("\n")
   s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables = `git ls-files -- bin/*`


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436