### PR TITLE
Add Ruby 3.2 to CI and update RuboCop

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -10,11 +10,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        ruby-version: ['2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby-version: ['2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -30,7 +31,7 @@ jobs:
         ruby-version: ['3.0']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,14 +1,17 @@
+require:
+  - rubocop-performance
+
 AllCops:
   TargetRubyVersion: 2.2
-
-Layout/AlignParameters:
-  EnforcedStyle: with_fixed_indentation
 
 Layout/EmptyLineBetweenDefs:
   Enabled: true
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
+
+Layout/ParameterAlignment:
+  EnforcedStyle: with_fixed_indentation
 
 Layout/SpaceAfterComma:
   Enabled: true
@@ -22,6 +25,10 @@ Layout/SpaceAroundOperators:
 Layout/SpaceBeforeSemicolon:
   Enabled: true
 
+Lint/MissingSuper:
+  Enabled: true
+  Exclude:
+    - lib/timezone/lookup/test.rb 
 
 Lint/DuplicateMethods:
   Enabled: true
@@ -103,7 +110,7 @@ Style/StringLiterals:
 Style/TrivialAccessors:
   Enabled: true
 
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: true
 
 Style/DateTime:

--- a/lib/timezone.rb
+++ b/lib/timezone.rb
@@ -39,14 +39,14 @@ module Timezone
   #
   # @raise [Timezone::Error::InvalidZone] if the timezone is not found
   #   and a default value and block have not been provided
-  def self.fetch(name, default = :__block, &block)
+  def self.fetch(name, default = :__block)
     return ::Timezone::Zone.new(name) if Loader.valid?(name)
 
     if block_given? && default != :__block
       warn('warning: block supersedes default value argument')
     end
 
-    return block.call(name) if block_given?
+    return yield(name) if block_given?
     return default unless default == :__block
 
     raise ::Timezone::Error::InvalidZone

--- a/lib/timezone/loader.rb
+++ b/lib/timezone/loader.rb
@@ -2,10 +2,10 @@
 
 require 'timezone/error'
 
-module Timezone # rubocop:disable Style/Documentation
+module Timezone
   # Responsible for loading and parsing timezone data from files.
   module Loader
-    ZONE_FILE_PATH = File.expand_path(File.dirname(__FILE__) + '/../../data')
+    ZONE_FILE_PATH = File.expand_path("#{File.dirname(__FILE__)}/../../data")
     SOURCE_BIT = 0
 
     @rules = {} # cache of loaded rules

--- a/lib/timezone/lookup.rb
+++ b/lib/timezone/lookup.rb
@@ -9,7 +9,7 @@ module Timezone
   # Configure timezone lookups.
   module Lookup
     class << self
-      MISSING_LOOKUP = 'No lookup configured'.freeze
+      MISSING_LOOKUP = 'No lookup configured'
       private_constant :MISSING_LOOKUP
 
       # Returns the lookup object
@@ -45,7 +45,7 @@ module Timezone
         test: ::Timezone::Lookup::Test
       }.freeze
 
-      INVALID_LOOKUP = 'Invalid lookup specified'.freeze
+      INVALID_LOOKUP = 'Invalid lookup specified'
 
       attr_reader :config
 

--- a/lib/timezone/lookup/geonames.rb
+++ b/lib/timezone/lookup/geonames.rb
@@ -38,7 +38,7 @@ module Timezone
 
         return unless data['status']
 
-        return if NO_TIMEZONE_INFORMATION == data['status']['value']
+        return if data['status']['value'] == NO_TIMEZONE_INFORMATION
 
         raise(Timezone::Error::GeoNames, data['status']['message'])
       rescue StandardError => e
@@ -55,6 +55,7 @@ module Timezone
         return unless data['gmtOffset'].is_a? Numeric
 
         return 'Etc/UTC' if data['gmtOffset'].zero?
+
         "Etc/GMT#{format('%+d', -data['gmtOffset'])}"
       end
 

--- a/lib/timezone/lookup/google.rb
+++ b/lib/timezone/lookup/google.rb
@@ -14,7 +14,7 @@ module Timezone
     class Google < ::Timezone::Lookup::Basic
       # Indicates that no time zone data could be found for the specified
       # <lat, lng>. This can occur if the query is incomplete or ambiguous.
-      NO_TIMEZONE_INFORMATION = 'ZERO_RESULTS'.freeze
+      NO_TIMEZONE_INFORMATION = 'ZERO_RESULTS'
 
       def initialize(config)
         if config.api_key.nil?
@@ -35,6 +35,7 @@ module Timezone
         end
 
         return unless response.code =~ /^2\d\d$/
+
         data = JSON.parse(response.body)
 
         return if data['status'] == NO_TIMEZONE_INFORMATION

--- a/lib/timezone/parser.rb
+++ b/lib/timezone/parser.rb
@@ -9,7 +9,7 @@ module Timezone
     MIN_YEAR = -500
     MAX_YEAR = 2039
 
-    LINE = /\s*(.+)\s*=\s*(.+)\s*isdst=(\d+)\s*gmtoff=([\+\-]*\d+)/
+    LINE = /\s*(.+)\s*=\s*(.+)\s*isdst=(\d+)\s*gmtoff=([+-]*\d+)/.freeze
 
     # Bookkeeping files that we do not want to parse.
     IGNORE = ['leapseconds', 'posixrules', 'tzdata.zi'].freeze
@@ -25,6 +25,7 @@ module Timezone
         next if File.directory?(file)
         next if file.end_with?('.tab')
         next if IGNORE.include?(File.basename(file))
+
         parse(file)
       end
     end
@@ -65,7 +66,7 @@ module Timezone
       def parse_offset(offset)
         arity = offset.start_with?('-') ? -1 : 1
 
-        match = offset.match(/^[\-\+](\d{2})$/)
+        match = offset.match(/^[-+](\d{2})$/)
         arity * match[1].to_i * 60 * 60
       end
     end
@@ -76,10 +77,10 @@ module Timezone
     class Line
       attr_accessor :source, :name, :dst, :offset
 
-      SOURCE_FORMAT = '%a %b %e %H:%M:%S %Y %Z'.freeze
+      SOURCE_FORMAT = '%a %b %e %H:%M:%S %Y %Z'
 
       def initialize(match)
-        self.source = Time.strptime(match[1] + 'C', SOURCE_FORMAT).to_i
+        self.source = Time.strptime("#{match[1]}C", SOURCE_FORMAT).to_i
         self.name = match[2].split(' ').last
         self.dst = match[3].to_i
         self.offset = match[4].to_i

--- a/lib/timezone/version.rb
+++ b/lib/timezone/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Timezone
-  VERSION = '1.3.23'.freeze
+  VERSION = '1.3.23'
 end

--- a/lib/timezone/zone.rb
+++ b/lib/timezone/zone.rb
@@ -6,7 +6,6 @@ require 'time'
 
 require 'timezone/loader'
 require 'timezone/error'
-require 'timezone/loader'
 
 module Timezone
   # This object represents a real-world timezone. Each instance provides
@@ -187,7 +186,7 @@ module Timezone
     #
     # Each rule has a SOURCE bit which is the number of seconds, since the
     # Epoch, up to which the rule is valid.
-    def match?(seconds, rule) #:nodoc:
+    def match?(seconds, rule) # :nodoc:
       seconds <= rule[SOURCE_BIT]
     end
 

--- a/test/test_timezone.rb
+++ b/test/test_timezone.rb
@@ -20,7 +20,7 @@ class TestTimezone < ::Minitest::Test
 
   def test_fetch
     assert Timezone.fetch('Australia/Sydney').valid?
-    assert_equal 'foo', Timezone.fetch('foo/bar') { 'foo' }
+    assert_equal 'foo', Timezone.fetch('foo/bar', 'foo')
     assert_raises Timezone::Error::InvalidZone do
       Timezone.fetch('foo/bar')
     end

--- a/test/timezone/lookup/test_geonames.rb
+++ b/test/timezone/lookup/test_geonames.rb
@@ -40,7 +40,7 @@ class TestGeonames < ::Minitest::Test
   end
 
   def test_lookup
-    mine = lookup(File.open(mock_path + '/lat_lon_coords.txt').read)
+    mine = lookup(File.open("#{mock_path}/lat_lon_coords.txt").read)
 
     assert_equal 'Australia/Adelaide', mine.lookup(*coordinates)
   end
@@ -55,7 +55,7 @@ class TestGeonames < ::Minitest::Test
   end
 
   def test_wrong_offset
-    body = File.open(mock_path + '/lat_lon_coords_wrong_offset.txt').read
+    body = File.open("#{mock_path}/lat_lon_coords_wrong_offset.txt").read
     mine = lookup(body) { |c| c.offset_etc_zones = true }
 
     assert_nil mine.lookup(*coordinates)
@@ -80,7 +80,7 @@ class TestGeonames < ::Minitest::Test
   end
 
   def test_api_limit
-    mine = lookup(File.open(mock_path + '/api_limit_reached.json').read)
+    mine = lookup(File.open("#{mock_path}/api_limit_reached.json").read)
 
     assert_exception(
       mine,
@@ -90,19 +90,19 @@ class TestGeonames < ::Minitest::Test
   end
 
   def test_invalid_latlong
-    mine = lookup(File.open(mock_path + '/invalid_latlong.json').read)
+    mine = lookup(File.open("#{mock_path}/invalid_latlong.json").read)
 
     assert_exception(mine, 'invalid lat/lng')
   end
 
   def test_no_result_found
-    mine = lookup(File.open(mock_path + '/no_result_found.json').read)
+    mine = lookup(File.open("#{mock_path}/no_result_found.json").read)
 
     assert_nil(mine.lookup(10, 10))
   end
 
   def test_invalid_parameter
-    mine = lookup(File.open(mock_path + '/invalid_parameter.json').read)
+    mine = lookup(File.open("#{mock_path}/invalid_parameter.json").read)
 
     assert_exception(mine, 'error parsing parameter')
   end

--- a/test/timezone/lookup/test_google.rb
+++ b/test/timezone/lookup/test_google.rb
@@ -33,7 +33,7 @@ class TestGoogle < ::Minitest::Test
   end
 
   def test_google_using_lat_long_coordinates
-    mine = lookup(File.open(mock_path + '/google_lat_lon_coords.txt').read)
+    mine = lookup(File.open("#{mock_path}/google_lat_lon_coords.txt").read)
 
     assert_equal 'Australia/Adelaide', mine.lookup(*coordinates)
   end
@@ -76,7 +76,7 @@ class TestGoogle < ::Minitest::Test
   end
 
   def test_no_result_found
-    mine = lookup(File.open(mock_path + '/google_no_result_found.json').read)
+    mine = lookup(File.open("#{mock_path}/google_no_result_found.json").read)
 
     assert_nil(mine.lookup(26.188703, -78.987053))
   end

--- a/test/timezone/test_lookup.rb
+++ b/test/timezone/test_lookup.rb
@@ -8,7 +8,7 @@ class TestLookup < ::Minitest::Test
     Timezone::Lookup.config(:test)
 
     assert_equal Timezone::Lookup::Test,
-      Timezone::Lookup.lookup.class
+                 Timezone::Lookup.lookup.class
   end
 
   def test_geonames_config
@@ -17,10 +17,10 @@ class TestLookup < ::Minitest::Test
     end
 
     assert_equal Timezone::Lookup::Geonames,
-      Timezone::Lookup.lookup.class
+                 Timezone::Lookup.lookup.class
 
     assert_equal Timezone::NetHTTPClient,
-      Timezone::Lookup.lookup.config.request_handler
+                 Timezone::Lookup.lookup.config.request_handler
   end
 
   def test_google_config
@@ -29,10 +29,10 @@ class TestLookup < ::Minitest::Test
     end
 
     assert_equal Timezone::Lookup::Google,
-      Timezone::Lookup.lookup.class
+                 Timezone::Lookup.lookup.class
 
     assert_equal Timezone::NetHTTPClient,
-      Timezone::Lookup.lookup.config.request_handler
+                 Timezone::Lookup.lookup.config.request_handler
   end
 
   def test_custom_config

--- a/timezone.gemspec
+++ b/timezone.gemspec
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
-# -*- encoding: utf-8 -*-
 
-$:.push File.expand_path('../lib', __FILE__)
+$:.push File.expand_path('lib', __dir__)
 require 'timezone/version'
 
 Gem::Specification.new do |s|
@@ -25,8 +24,11 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ['--charset=UTF-8']
   s.require_paths    = ['lib']
 
+  s.required_ruby_version = '>= 2.2'
+
   s.add_development_dependency('minitest', '~> 5.8')
   s.add_development_dependency('rake', '~> 12')
-  s.add_development_dependency('rubocop', '= 0.51')
+  s.add_development_dependency('rubocop', '>= 0.51')
+  s.add_development_dependency('rubocop-performance')
   s.add_development_dependency('timecop', '~> 0.8')
 end


### PR DESCRIPTION
This PR adds Ruby 3.2 to the CI matrix and updates RuboCop to a version that can be run with that Ruby version.

Getting everything green required:

1. Updating the .rubocop.yml to account for Cop name changes
2. Adding rubocop-performance to the gemspec and config
3. Some minor changes to address lints
4. Disabling the Lint/MissingSuper for the `Timezone::Lookup::Test` class, because that missing super is a deliberate strategy for that class.

Everything runs green on my fork.