### PR TITLE
Add changelog_uri to gemspec metadata

### DIFF
--- a/timezone.gemspec
+++ b/timezone.gemspec
@@ -15,6 +15,10 @@ Gem::Specification.new do |s|
   s.description = 'Accurate current and historical timezones for Ruby with ' \
     'support for Geonames and Google latitude - longitude lookups.'
 
+  s.metadata =    {
+    'changelog_uri' => 'https://github.com/panthomakos/timezone/blob/master/CHANGES.markdown'
+  }
+
   s.files       = `git ls-files`.split("\n")
   s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables = `git ls-files -- bin/*`


### PR DESCRIPTION
Makes it easier to navigate to the changelog from rubygems.org or CLI tools which use this field :)